### PR TITLE
fix: correctly attach item before use

### DIFF
--- a/src/core/app/types.ts
+++ b/src/core/app/types.ts
@@ -6,8 +6,8 @@ export interface AppConfig {
 
 export interface PropertyType {
   key: string;
-  setValidator: (param: any) => boolean;
-  setTransformer: (param: any) => any;
-  getValidator: (param: any) => boolean;
-  getTransformer: (param: any) => any;
+  setValidator?: (param: any) => boolean;
+  setTransformer?: (param: any) => any;
+  getValidator?: (param: any) => boolean;
+  getTransformer?: (param: any) => any;
 }

--- a/src/core/item/item.ts
+++ b/src/core/item/item.ts
@@ -65,8 +65,8 @@ class Item {
     return placements.reduce((stack: string[], scene: any) => {
       const sceneItems: any[] = scene.item || [];
       const linkedItems: string[] = sceneItems
-        .filter(item => item.srcid === this._srcId)
-        .map(item => item.id);
+        .filter((item) => item.srcid === this._srcId)
+        .map((item) => item.id);
 
       return [...stack, ...linkedItems];
     }, []);
@@ -82,7 +82,7 @@ class Item {
         items = [items];
       }
 
-      const item = items.find(item => item.srcid === this._srcId);
+      const item = items.find((item) => item.srcid === this._srcId);
 
       if (item) {
         return item.id;
@@ -115,7 +115,7 @@ class Item {
       // checking for both the string "null" and the actual null value.
       // @TODO: If core always returns null, this would cause a callstack exceeded error
       // Address this before releasing 3.x, if it is something to worry about.
-      if (result === null || result === 'null') {
+      if (!isNaN(result) && Number(result) < 0) {
         console.warn(
           'Attached item does not exist. Attempting to attach linked item...'
         );

--- a/src/core/item/item.ts
+++ b/src/core/item/item.ts
@@ -41,34 +41,129 @@ class Item {
     this._isCurrentItem = !!config.isCurrentItem;
   }
 
-  setProperty(prop: PropertyType, param: any): Promise<any> {
-    if (typeof prop.setValidator !== 'function' || prop.setValidator(param)) {
-      if (!Environment.isSourcePlugin) {
-        this._internal.exec('SearchVideoItem', this._id);
-      }
+  private async getPlacements() {
+    const presentationXml = await this._internal.exec(
+      'AppGetPropertyAsync',
+      'sceneconfig'
+    );
+    const presentationObj = parser.parse(presentationXml, {
+      attributeNamePrefix: '',
+      ignoreAttributes: false,
+    });
 
-      return this._internal.exec(
-        'SetLocalPropertyAsync',
+    if (!presentationObj || !presentationObj.configuration) {
+      return [];
+    }
+
+    return presentationObj.configuration.placement || [];
+  }
+
+  async getItemList() {
+    const placements = await this.getPlacements();
+
+    // O(n^2)
+    return placements.reduce((stack: string[], scene: any) => {
+      const sceneItems: any[] = scene.item || [];
+      const linkedItems: string[] = sceneItems
+        .filter((item) => item.srcid === this._srcId)
+        .map((item) => item.id);
+
+      return [...stack, ...linkedItems];
+    }, []);
+  }
+
+  async getLinkedItem() {
+    const placements = await this.getPlacements();
+
+    for (let idx = 0; idx < placements.length; idx++) {
+      const items = placements[idx].item;
+      const item = items.find((item) => item.srcid === this._srcId);
+
+      if (item) {
+        return item.id;
+      }
+    }
+
+    return '';
+  }
+
+  async setProperty(prop: PropertyType, param: any) {
+    if (typeof prop.setValidator !== 'function' || prop.setValidator(param)) {
+      const attachKey = Environment.isSourcePlugin
+        ? 'AttachVideoItem1'
+        : 'SearchVideoItem';
+      const funcKey = Environment.isSourcePlugin
+        ? 'SetLocalPropertyAsync1'
+        : 'SetLocalPropertyAsync';
+
+      this._internal.exec(attachKey, this._id);
+
+      const result = await this._internal.exec(
+        funcKey,
         prop.key,
         typeof prop.setTransformer !== 'function'
           ? param
           : prop.setTransformer(param)
       );
+
+      // deadcoldbrain noted that it is much safer if we do this comparison,
+      // checking for both the string "null" and the actual null value.
+      // @TODO: If core always returns null, this would cause a callstack exceeded error
+      // Address this before releasing 3.x, if it is something to worry about.
+      if (result === null || result === 'null') {
+        console.warn(
+          'Attached item does not exist. Attempting to attach linked item...'
+        );
+
+        this._id = await this.getLinkedItem();
+
+        if (this._id) {
+          return this.setProperty(prop, param);
+        } else {
+          console.error('Failed to find linked item.');
+        }
+      } else {
+        return result;
+      }
     }
 
     throw new Error(`Params "${param}" validation failed`);
   }
 
-  async getProperty(prop: PropertyType, param: any): Promise<any> {
+  async getProperty(prop: PropertyType, param: any) {
     if (typeof prop.getValidator !== 'function' || prop.getValidator(param)) {
-      if (!Environment.isSourcePlugin) {
-        this._internal.exec('SearchVideoItem', this._id);
-      }
+      const attachKey = Environment.isSourcePlugin
+        ? 'AttachVideoItem1'
+        : 'SearchVideoItem';
+      const funcKey = Environment.isSourcePlugin
+        ? 'GetLocalPropertyAsync1'
+        : 'GetLocalPropertyAsync';
 
-      const ret = await this._internal.exec('GetLocalPropertyAsync', prop.key);
-      return typeof prop.getTransformer !== 'function'
-        ? ret
-        : prop.getTransformer(ret);
+      this._internal.exec(attachKey, this._id);
+
+      const result = await this._internal.exec(funcKey, prop.key);
+
+      // deadcoldbrain noted that it is much safer if we do this comparison,
+      // checking for both the string "null" and the actual null value.
+      // @TODO: If core always returns null, this would cause a callstack exceeded error
+      // Address this before releasing 3.x, if it is something to worry about.
+      if (result === null || result === 'null') {
+        console.warn(
+          'Attached item does not exaist. Attempting to attach linked item...'
+        );
+
+        this._id = await this.getLinkedItem();
+
+        if (this._id) {
+          return this.getProperty(prop, param);
+        } else {
+          console.error('Failed to find linked item.');
+        }
+      } else {
+        return typeof prop.getTransformer !== 'function'
+          ? result
+          : prop.getTransformer(result);
+      }
     }
 
     throw new Error(`Params "${param}" validation failed`);
@@ -108,9 +203,7 @@ class Item {
       result = await this._internal.exec('GetConfiguration');
     }
 
-    const config = JSON.parse(result || '{}');
-
-    return config;
+    return JSON.parse(result || '{}');
   }
 }
 

--- a/src/core/item/item.ts
+++ b/src/core/item/item.ts
@@ -65,8 +65,8 @@ class Item {
     return placements.reduce((stack: string[], scene: any) => {
       const sceneItems: any[] = scene.item || [];
       const linkedItems: string[] = sceneItems
-        .filter((item) => item.srcid === this._srcId)
-        .map((item) => item.id);
+        .filter(item => item.srcid === this._srcId)
+        .map(item => item.id);
 
       return [...stack, ...linkedItems];
     }, []);
@@ -76,8 +76,13 @@ class Item {
     const placements = await this.getPlacements();
 
     for (let idx = 0; idx < placements.length; idx++) {
-      const items = placements[idx].item;
-      const item = items.find((item) => item.srcid === this._srcId);
+      let items = placements[idx].item || [];
+
+      if (!(items instanceof Array)) {
+        items = [items];
+      }
+
+      const item = items.find(item => item.srcid === this._srcId);
 
       if (item) {
         return item.id;

--- a/src/props/app-props.ts
+++ b/src/props/app-props.ts
@@ -8,9 +8,6 @@ class AppProps {
 
       return true;
     },
-    setTransformer: (xml: string) => xml,
-    getValidator: () => true,
-    getTransformer: (xml: string) => xml,
   };
 
   static sceneIndex = {
@@ -29,7 +26,7 @@ class AppProps {
       return true;
     },
     setTransformer: (value: any) => value.value,
-    getValidator: param => {
+    getValidator: (param) => {
       if (typeof param !== 'object' || typeof param.view === 'undefined') {
         throw new Error(
           'Parameter should be an object with a `value` property'
@@ -38,7 +35,6 @@ class AppProps {
 
       return true;
     },
-    getTransformer: (sceneIndex: string) => sceneIndex,
   };
 
   static scenePreset = {
@@ -50,9 +46,6 @@ class AppProps {
 
       return true;
     },
-    setTransformer: (xml: string) => xml,
-    getValidator: () => true,
-    getTransformer: (xml: string) => xml,
   };
 
   static scenePresetList = {
@@ -64,9 +57,6 @@ class AppProps {
 
       return true;
     },
-    setTransformer: (xml: string) => xml,
-    getValidator: () => true,
-    getTransformer: (xml: string) => xml,
   };
 
   static microphoneDev2 = {
@@ -78,9 +68,6 @@ class AppProps {
 
       return true;
     },
-    setTransformer: (xml: string) => xml,
-    getValidator: () => true,
-    getTransformer: (xml: string) => xml,
   };
 
   static wasapiEnum = {
@@ -92,9 +79,6 @@ class AppProps {
 
       return true;
     },
-    setTransformer: (xml: string) => xml,
-    getValidator: () => true,
-    getTransformer: (xml: string) => xml,
   };
 
   static sceneItems = {
@@ -122,9 +106,6 @@ class AppProps {
 
       return true;
     },
-    // We opted to just return the exact string based on our discussion regarding the tradeoffs
-    // on return an object that would represent the "processed" xml config.
-    getTransformer: (xml: string) => xml,
   };
 
   static sceneName = {
@@ -152,7 +133,6 @@ class AppProps {
 
       return true;
     },
-    getTransformer: (name: string) => name,
   };
 
   static audioDevices = AppProps.microphoneDev2;


### PR DESCRIPTION
## Correctly attach item on source plugins

- Fix the wrong assumption made about the source plugin context. The fix here is that the `item.set/getProperty` methods would always attach the item before setting or getting the properties.
- Apply fallback when current item is deleted, but there's a linked source somewhere in the presentation.
  - If in case the current item was deleted, our methods would auto attach the first linked source returned when traversing the presentation.

This PR also includes changes in the App Properties, that should only require the app property object to have a `key`, while the validators and transformers are now optional.