### PR TITLE
feat: initial changes for app event handling

### DIFF
--- a/src/core/events/events.ts
+++ b/src/core/events/events.ts
@@ -1,0 +1,43 @@
+import { EventMetaDataType } from './types';
+
+/**
+ * @TODO: This is currently only used for stream events
+ */
+
+let eventCallbacks = {};
+function parseSegments(segments: string[]): any {
+  const parsed = segments.reduce((obj, current) => {
+    const [key, value] = String(current).split('=');
+
+    return { ...obj, [key]: decodeURIComponent(value) };
+  }, {});
+
+  return parsed;
+}
+
+window.SetEvent = (value: string) => {
+  const segments = String(value).split('&');
+  const { event, info } = parseSegments(segments);
+
+  if (Array.isArray(eventCallbacks[event])) {
+    eventCallbacks[event].forEach(callback => {
+      if (typeof callback === 'function') {
+        callback(decodeURIComponent(info));
+      }
+    });
+  }
+};
+
+export default {
+  subscribe: ({ environmentValidator, key }: EventMetaDataType, callback) => {
+    if (typeof environmentValidator === 'function' && !environmentValidator()) {
+      return;
+    }
+
+    if (typeof eventCallbacks[key] === 'undefined') {
+      eventCallbacks[key] = [];
+    }
+
+    eventCallbacks[key].push(callback);
+  },
+};

--- a/src/core/events/index.ts
+++ b/src/core/events/index.ts
@@ -1,0 +1,1 @@
+export { default } from './events';

--- a/src/core/events/types.ts
+++ b/src/core/events/types.ts
@@ -1,0 +1,4 @@
+export type EventMetaDataType = {
+  key: string;
+  environmentValidator: () => boolean;
+};

--- a/types/window.d.ts
+++ b/types/window.d.ts
@@ -4,6 +4,7 @@ declare global {
   interface Window {
     OnAsyncCallback: any;
     OnPropsMessageReceive: (payload: string) => any;
+    SetEvent: (value: string) => void;
     // external: XSplitExternal; // @TODO: Typescript does not yet allow this...
   }
 }


### PR DESCRIPTION
This change includes the initial implementation of app event handling based on what we discussed in our meetings

### Usage:
```javascript
import Events from '@dcefram/xjs/core/events';

Events.subscribe({ key: 'StreamStart' }, () => {
  console.log('stream has started!');
});
```

The reason why we opted to pass in objects is that the plan was that the framework would also provide a list of *events*, similar to how we provide a list of app and item properties. The object would also include a function called `environmentValidator` that would be used to prevent using an event that isn't available to a particular environment.

```javascript
// Possible implementation of an events object?
const EventTypes = {
  StreamStart: {
    key: 'StreamStart',
    environmentValidator: () => Environment.isSourcePlugin(); // This is just to demonstrate the possible use of `environmentValidator`
  },
  StreamEnd: { .... }
}
```

This PR will also serve as a RFC for the events system, if this is indeed what we think is the best implementation.